### PR TITLE
Remove invalid chapters from css

### DIFF
--- a/src/css/sheet-jqueryui.php
+++ b/src/css/sheet-jqueryui.php
@@ -305,7 +305,7 @@ div.ui-datebox-container.ui-datebox-inline {
 	margin-right: auto;
 	margin-left: auto;
 	position: relative;
-	-webkit-box-shadow: 0 0 12px rgba(0,0,0,.6); */
+	-webkit-box-shadow: 0 0 12px rgba(0,0,0,.6);
     -moz-box-shadow: 0 0 12px rgba(0,0,0,.6);
     box-shadow: 0 0 12px rgba(0,0,0,.6);
 }


### PR DESCRIPTION
There is issue in generated code:
![selection_596](https://user-images.githubusercontent.com/1978331/40922761-abf09ca4-681b-11e8-82c4-eaa5f2b79bb4.png)
That was produce error while minification using assetic in symfony:
![selection_595](https://user-images.githubusercontent.com/1978331/40922797-c977a394-681b-11e8-958b-511917a6c8e8.png)
Tools doesn't matter in this case, it is just an error in css.