### PR TITLE
Update calStartDay for Norwegian translation to 1 (Monday)

### DIFF
--- a/i18n/locale/no/datebox.po
+++ b/i18n/locale/no/datebox.po
@@ -285,8 +285,8 @@ msgstr "false"
 
 #. Set to the start day of the calendar (0=Sunday)
 #: generate-i18n.py:42
-msgid "0"
-msgstr "0"
+msgid "1"
+msgstr "1"
 
 #: generate-i18n.py:43
 msgid "Clear"

--- a/i18n/locale/no/datebox.po
+++ b/i18n/locale/no/datebox.po
@@ -285,7 +285,7 @@ msgstr "false"
 
 #. Set to the start day of the calendar (0=Sunday)
 #: generate-i18n.py:42
-msgid "1"
+msgid "0"
 msgstr "1"
 
 #: generate-i18n.py:43


### PR DESCRIPTION
### Requirements for Contributing

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Identify the Bug
I'll create an issue if it's needed. As it's only a translation modification, I'll try a direct PR first.

### Description of the Change
The Norwegian translation has the first day of the week set to 0 (Sunday). That is not the case in Norway. The first day of the week is Monday.

### Alternate Designs
N/A
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
N/A, I think.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
N/A. A modification to the start day translation shouldn't cause and regressions.
<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, etc.), and describe the results you observed.

-->

First time contributing, so apologies if I've done something wrong.